### PR TITLE
Wait for transactions to clear before submitting new ones.

### DIFF
--- a/wl_daemon/whitelisting.py
+++ b/wl_daemon/whitelisting.py
@@ -24,7 +24,25 @@ class Whitelisting(DaemonThread):
         self.whitelisted=set()
         self.toblacklist=set()
         self.blacklisted=set()
+        self.pendingtx=set()
 
+    #Returns true if there are no pending transactions
+    def update_pendingtx(self):
+        rmp_set=set()
+        try:
+            rmp=self.ocean.getrawmempool()
+            rmp_set=set(rmp)
+            del rmp[:]
+        except Exception as e:
+            self.logger.warning("getrawmempool error{}: {}".format(p, e))
+            return False
+        self.pendingtx=self.pendingtx.intersection(rmp_set)
+        nPending=len(self.pendingtx)
+        bNonePending=(nPending == 0)
+        if bNonePending == False:
+            self.logger.warning("update_pendingtx: {} pending".format(nPending))
+        return bNonePending
+        
     def update_files(self):
         self.towhitelist=set()
         self.logger.info("searching {} for kycfiles".format(self.conf["kyc_indir"]))
@@ -90,6 +108,8 @@ class Whitelisting(DaemonThread):
             self.logger.info("blockcount:{}".format(height))
             if height <= self.previous_height:
                 continue
+            if self.update_pendingtx() != True:
+                continue
             self.update_files()
             self.update_status()
             self.onboard_kycfiles()
@@ -118,7 +138,8 @@ class Whitelisting(DaemonThread):
             p=os.path.join(self.conf["kyc_indir"], f)
             try:
                 self.logger.info("onboarding file {}".format(p))
-                self.onboard_kycfile(p)
+                txid=self.onboard_kycfile(p)
+                self.pendingtx.add(txid)
             except Exception as e:
                 self.logger.error(e)
                 mess='error when onboarding kycfile ' + p
@@ -136,7 +157,8 @@ class Whitelisting(DaemonThread):
             p=os.path.join(self.conf["kyc_toblacklistdir"], f)
             try:
                 self.logger.info("blacklisting file {}".format(p))
-                self.blacklist_kycfile(p)
+                txid=self.blacklist_kycfile(p)
+                self.pendingtx.add(txid)
             except Exception as e:
                 self.logger.error(e)
                 mess='error when blacklisting kycfile ' + p


### PR DESCRIPTION
This is to prevent duplicate transactions being submitted.